### PR TITLE
The letter 'z' was not a possible letter in mutation

### DIFF
--- a/C#/GAHelloWorld/Chromosome.cs
+++ b/C#/GAHelloWorld/Chromosome.cs
@@ -83,7 +83,7 @@ namespace GAHelloWorld
             char[] mutatedGene = this.Gene.ToCharArray();
 
             int randomIndex = rand.Next(0, this.Gene.Length);
-            int mutateChange = rand.Next(32, 122);
+            int mutateChange = rand.Next(32, 123);
 
             mutatedGene[randomIndex] = (char)mutateChange;
 

--- a/clojure/src/net/auxesia/chromosome.clj
+++ b/clojure/src/net/auxesia/chromosome.clj
@@ -50,7 +50,7 @@
   [c]
   (let [old-gene (:gene c)
 	    idx (rand-int (count old-gene))
-	    new-gene (assoc old-gene idx (char (mod (+ (int (get old-gene idx)) (+ 32 (rand-int 90))) 122)))]
+	    new-gene (assoc old-gene idx (char (mod (+ (int (get old-gene idx)) (+ 32 (rand-int 90))) 123)))]
     (Chromosome. new-gene (fitness new-gene))))
 
 (defn generate

--- a/java/src/main/java/net/auxesia/Chromosome.java
+++ b/java/src/main/java/net/auxesia/Chromosome.java
@@ -113,7 +113,7 @@ public class Chromosome implements Comparable<Chromosome> {
 		char[] arr  = gene.toCharArray();
 		int idx     = rand.nextInt(arr.length);
 		int delta   = (rand.nextInt() % 90) + 32;
-		arr[idx]    = (char) ((arr[idx] + delta) % 122);
+		arr[idx]    = (char) ((arr[idx] + delta) % 123);
 
 		return new Chromosome(String.valueOf(arr));
 	}

--- a/python/gahelloworld.py
+++ b/python/gahelloworld.py
@@ -71,7 +71,7 @@ class Chromosome:
         gene = list(self.gene)
         delta = randint(32, 121)
         idx = randint(0, len(gene) - 1)
-        gene[idx] = chr((ord(gene[idx]) + delta) % 122)
+        gene[idx] = chr((ord(gene[idx]) + delta) % 123)
         
         return Chromosome(''.join(gene))
 

--- a/ruby/lib/gahelloworld.rb
+++ b/ruby/lib/gahelloworld.rb
@@ -23,7 +23,7 @@
 module GAHelloWorld
   RAND_SEED=srand
   TARGET_GENE='Hello World!'
-  ALLOWED_LETTERS = (32..122).to_a.map{|i| i.chr}
+  ALLOWED_LETTERS = (32..123).to_a.map{|i| i.chr}
 
   class Chromosome
     attr_reader :gene_ary, :target_ary, :gene

--- a/scala/src/main/scala/net/auxesia/Chromosome.scala
+++ b/scala/src/main/scala/net/auxesia/Chromosome.scala
@@ -104,7 +104,7 @@ object Chromosome {
    */
   def mutate(ch: Chromosome) = {
     var arr = ch.gene.toArray
-    arr(Random.nextInt(ch.gene.length)) = (Random.nextInt(90) + 32).toChar
+    arr(Random.nextInt(ch.gene.length)) = (Random.nextInt(91) + 32).toChar
     Chromosome(arr.mkString)
   }
 }


### PR DESCRIPTION
First of all thank you for the code that you have provided, it saved me a lot of time!
I encountered this bug while messing around the java code. I tried to use the algorithm with a string that contained 'z' and iterating, because it was not possible for 'z' to occur in the mutation.
I fixed this in the java code and in C#, clojure, python, ruby and scala.
